### PR TITLE
#53: Integrated Mac and Windows Circleci workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,6 +141,8 @@ jobs:
       xcode: "14.2.0"
     steps:
       - checkout
+      - setup_remote_docker:
+          docker_layer_caching: false
       - run:
           name: "Run integration tests in mac"
           command: "./gradlew integrationTest --no-configuration-cache --no-build-cache --no-configure-on-demand --stacktrace"
@@ -158,6 +160,8 @@ jobs:
       xcode: "14.2.0"
     steps:
       - checkout
+      - setup_remote_docker:
+          docker_layer_caching: false
       - run:
           name: "Run functional tests in mac"
           command: "./gradlew functionalTest --no-configuration-cache --no-build-cache --no-configure-on-demand --stacktrace"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ jobs:
           paths:
             - ~/.gradle/caches/
           key: gradle-cache-{{ checksum "build.gradle.kts" }}-{{ checksum "settings.gradle.kts" }}
+
   gradle-build-test-unix:
     docker:
       - image: cimg/openjdk:11.0.22
@@ -42,6 +43,7 @@ jobs:
           when: always
       - store_test_results:
           path: ~/test-results
+
   gradle-unit-test-unix:
     docker:
       - image: cimg/openjdk:11.0.22
@@ -62,6 +64,10 @@ jobs:
           when: always
       - store_test_results:
           path: ~/test-results
+      - store_artifacts:
+          path: ~/test-results/junit/
+          destination: test-results
+
   gradle-integration-test-unix:
     docker:
       - image: cimg/openjdk:11.0.22
@@ -84,6 +90,10 @@ jobs:
           when: always
       - store_test_results:
           path: ~/test-results
+      - store_artifacts:
+          path: ~/test-results/junit/
+          destination: test-results
+
   gradle-functional-test-unix:
     docker:
       - image: cimg/openjdk:11.0.22
@@ -107,7 +117,9 @@ jobs:
           when: always
       - store_test_results:
           path: ~/test-results
-
+      - store_artifacts:
+          path: ~/test-results/junit/
+          destination: test-results
 
   #       ------------------ MAC ------------------
   gradle-build-mac:
@@ -135,6 +147,9 @@ jobs:
           when: always
       - store_test_results:
           path: ~/test-results
+      - store_artifacts:
+          path: ~/test-results/junit/
+          destination: test-results
 
   gradle-integration-test-mac:
     macos:
@@ -154,6 +169,9 @@ jobs:
           when: always
       - store_test_results:
           path: ~/test-results
+      - store_artifacts:
+          path: ~/test-results/junit/
+          destination: test-results
 
   gradle-functional-test-mac:
     macos:
@@ -173,6 +191,9 @@ jobs:
           when: always
       - store_test_results:
           path: ~/test-results
+      - store_artifacts:
+          path: ~/test-results/junit/
+          destination: test-results
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,8 +65,8 @@ jobs:
       - store_test_results:
           path: ~/test-results
       - store_artifacts:
-          path: ~/test-results/junit/
-          destination: test-results
+          path: ~/reports/tests/test
+          destination: test-results/unit
 
   gradle-integration-test-unix:
     docker:
@@ -91,8 +91,8 @@ jobs:
       - store_test_results:
           path: ~/test-results
       - store_artifacts:
-          path: ~/test-results/junit/
-          destination: test-results
+          path: ~/reports/tests/integrationTest
+          destination: test-results/integration
 
   gradle-functional-test-unix:
     docker:
@@ -118,8 +118,8 @@ jobs:
       - store_test_results:
           path: ~/test-results
       - store_artifacts:
-          path: ~/test-results/junit/
-          destination: test-results
+          path: ~/reports/tests/functionalTest
+          destination: test-results/functional
 
   #       ------------------ MAC ------------------
   gradle-build-mac:
@@ -148,16 +148,14 @@ jobs:
       - store_test_results:
           path: ~/test-results
       - store_artifacts:
-          path: ~/test-results/junit/
-          destination: test-results
+          path: ~/reports/tests/test
+          destination: test-results/unit
 
   gradle-integration-test-mac:
     macos:
       xcode: "14.2.0"
     steps:
       - checkout
-      - setup_remote_docker:
-          docker_layer_caching: false
       - run:
           name: "Run integration tests in mac"
           command: "./gradlew integrationTest --no-configuration-cache --no-build-cache --no-configure-on-demand --stacktrace"
@@ -170,16 +168,14 @@ jobs:
       - store_test_results:
           path: ~/test-results
       - store_artifacts:
-          path: ~/test-results/junit/
-          destination: test-results
+          path: ~/reports/tests/integrationTest
+          destination: test-results/integration
 
   gradle-functional-test-mac:
     macos:
       xcode: "14.2.0"
     steps:
       - checkout
-      - setup_remote_docker:
-          docker_layer_caching: false
       - run:
           name: "Run functional tests in mac"
           command: "./gradlew functionalTest --no-configuration-cache --no-build-cache --no-configure-on-demand --stacktrace"
@@ -192,8 +188,8 @@ jobs:
       - store_test_results:
           path: ~/test-results
       - store_artifacts:
-          path: ~/test-results/junit/
-          destination: test-results
+          path: ~/reports/tests/functionalTest
+          destination: test-results/functional
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,34 +112,18 @@ jobs:
   #       ------------------ MAC ------------------
   gradle-build-mac:
     macos:
-      xcode: "14.0.0"
+      xcode: "14.2.0"
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
-            - gradle-cache-{{ checksum "build.gradle.kts" }}-{{ checksum "settings.gradle.kts" }}
       - run:
           name: "gradle assemble mac"
           command: "./gradlew assemble --no-configuration-cache --no-build-cache --no-configure-on-demand --stacktrace"
-      - save_cache:
-          paths:
-            - ~/.gradle/wrapper/
-          key: gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
-      - save_cache:
-          paths:
-            - ~/.gradle/caches/
-          key: gradle-cache-{{ checksum "build.gradle.kts" }}-{{ checksum "settings.gradle.kts" }}
 
   gradle-test-mac:
     macos:
-      xcode: "14.0.0"
+      xcode: "14.2.0"
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
-            - gradle-cache-{{ checksum "build.gradle.kts" }}-{{ checksum "settings.gradle.kts" }}
       - run:
           name: "Run unit tests in mac"
           command: "./gradlew test --no-configuration-cache --no-build-cache --no-configure-on-demand --stacktrace"
@@ -154,13 +138,9 @@ jobs:
 
   gradle-integration-test-mac:
     macos:
-      xcode: "14.0.0"
+      xcode: "14.2.0"
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
-            - gradle-cache-{{ checksum "build.gradle.kts" }}-{{ checksum "settings.gradle.kts" }}
       - run:
           name: "Run integration tests in mac"
           command: "./gradlew integrationTest --no-configuration-cache --no-build-cache --no-configure-on-demand --stacktrace"
@@ -175,13 +155,9 @@ jobs:
 
   gradle-functional-test-mac:
     macos:
-      xcode: "14.0.0"
+      xcode: "14.2.0"
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
-            - gradle-cache-{{ checksum "build.gradle.kts" }}-{{ checksum "settings.gradle.kts" }}
       - run:
           name: "Run functional tests in mac"
           command: "./gradlew functionalTest --no-configuration-cache --no-build-cache --no-configure-on-demand --stacktrace"
@@ -208,11 +184,17 @@ workflows:
       - gradle-functional-test-unix
   gradle-build-mac:
     jobs:
-      - gradle-build-mac
-  gradle-test-mac:
-    jobs:
-      - gradle-test-mac
-      - gradle-integration-test-mac
-  gradle-functional-test-mac:
-    jobs:
-      - gradle-functional-test-mac
+      - hold:
+          type: approval
+      - gradle-build-mac:
+          requires:
+            - hold
+      - gradle-test-mac:
+          requires:
+            - hold
+      - gradle-integration-test-mac:
+          requires:
+            - hold
+      - gradle-functional-test-mac:
+          requires:
+            - hold

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,15 +108,111 @@ jobs:
       - store_test_results:
           path: ~/test-results
 
+
+  #       ------------------ MAC ------------------
+  gradle-build-mac:
+    macos:
+      xcode: "14.0.0"
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
+            - gradle-cache-{{ checksum "build.gradle.kts" }}-{{ checksum "settings.gradle.kts" }}
+      - run:
+          name: "gradle assemble mac"
+          command: "./gradlew assemble --no-configuration-cache --no-build-cache --no-configure-on-demand --stacktrace"
+      - save_cache:
+          paths:
+            - ~/.gradle/wrapper/
+          key: gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
+      - save_cache:
+          paths:
+            - ~/.gradle/caches/
+          key: gradle-cache-{{ checksum "build.gradle.kts" }}-{{ checksum "settings.gradle.kts" }}
+
+  gradle-test-mac:
+    macos:
+      xcode: "14.0.0"
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
+            - gradle-cache-{{ checksum "build.gradle.kts" }}-{{ checksum "settings.gradle.kts" }}
+      - run:
+          name: "Run unit tests in mac"
+          command: "./gradlew test --no-configuration-cache --no-build-cache --no-configure-on-demand --stacktrace"
+      - run:
+          name: "Save test results mac"
+          command: |
+            mkdir -p ~/test-results/junit/
+            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/test-results/junit/ \;
+          when: always
+      - store_test_results:
+          path: ~/test-results
+
+  gradle-integration-test-mac:
+    macos:
+      xcode: "14.0.0"
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
+            - gradle-cache-{{ checksum "build.gradle.kts" }}-{{ checksum "settings.gradle.kts" }}
+      - run:
+          name: "Run integration tests in mac"
+          command: "./gradlew integrationTest --no-configuration-cache --no-build-cache --no-configure-on-demand --stacktrace"
+      - run:
+          name: "Save test results mac"
+          command: |
+            mkdir -p ~/test-results/junit/
+            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/test-results/junit/ \;
+          when: always
+      - store_test_results:
+          path: ~/test-results
+
+  gradle-functional-test-mac:
+    macos:
+      xcode: "14.0.0"
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - gradle-wrapper-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
+            - gradle-cache-{{ checksum "build.gradle.kts" }}-{{ checksum "settings.gradle.kts" }}
+      - run:
+          name: "Run functional tests in mac"
+          command: "./gradlew functionalTest --no-configuration-cache --no-build-cache --no-configure-on-demand --stacktrace"
+      - run:
+          name: "Save test results mac"
+          command: |
+            mkdir -p ~/test-results/junit/
+            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/test-results/junit/ \;
+          when: always
+      - store_test_results:
+          path: ~/test-results
+
+
 workflows:
-  gradle-build-unix-workflow:
+  gradle-build-unix:
     jobs:
       - gradle-build-unix
-  gradle-verify-unix-fast-workflow:
+  gradle-test-unix-fast:
     jobs:
-#      - gradle-build-test-unix   test convention plugin, perhaps it's overkill here
       - gradle-unit-test-unix
       - gradle-integration-test-unix
-  gradle-verify-unix-slow-workflow:
+  gradle-test-unix-slow:
     jobs:
       - gradle-functional-test-unix
+  gradle-build-mac:
+    jobs:
+      - gradle-build-mac
+  gradle-test-mac:
+    jobs:
+      - gradle-test-mac
+      - gradle-integration-test-mac
+  gradle-functional-test-mac:
+    jobs:
+      - gradle-functional-test-mac


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Integrate macOS workflows into the CircleCI configuration, adding jobs for building, testing, and running integration and functional tests on macOS. Rename existing Unix workflows for improved clarity.

CI:
- Add new CircleCI jobs for building, testing, and running integration and functional tests on macOS using Xcode 14.0.0.
- Integrate macOS workflows into the existing CircleCI configuration, including separate workflows for build, test, and functional tests.
- Rename existing Unix workflows for clarity and consistency with new macOS workflows.

<!-- Generated by sourcery-ai[bot]: end summary -->