### PR TITLE
#0: Enable parallel tests in CI

### DIFF
--- a/internal-convention-plugin/src/main/java/io/huskit/gradle/plugin/internal/ApplyInternalPluginLogic.java
+++ b/internal-convention-plugin/src/main/java/io/huskit/gradle/plugin/internal/ApplyInternalPluginLogic.java
@@ -168,7 +168,7 @@ public class ApplyInternalPluginLogic {
                                 environment.put("TESTCONTAINERS_REUSE_ENABLE", "true");
                                 test.setEnvironment(environment);
                                 var memory = test.getName().equals(JavaPlugin.TEST_TASK_NAME) ? "128m" : "512m";
-                                test.systemProperty("junit.jupiter.execution.parallel.enabled", internalEnvironment.isLocal());
+//                                test.systemProperty("junit.jupiter.execution.parallel.enabled", internalEnvironment.isLocal());
                                 test.setJvmArgs(
                                         Stream.of(
                                                         test.getName().equals("functionalTest") ?


### PR DESCRIPTION
## Summary by Sourcery

Disable parallel execution of JUnit Jupiter tests in the CI environment by commenting out the related system property setting.

CI:
- Disable the system property for enabling parallel execution of JUnit Jupiter tests in the CI environment.